### PR TITLE
Import performance increase

### DIFF
--- a/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/DazRigBlend.py
+++ b/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/DazRigBlend.py
@@ -183,53 +183,53 @@ class DazRigBlend:
                 for d in del_vgs:
                     vgs[d].add([v.index], 1.0, 'SUBTRACT')
 
-def integrationEyelashes(self):
-    Global.setOpsMode('OBJECT')
-    obj1 = Global.getEyls()
-    obj2 = Global.getBody()
-    eyelashkeys = obj1.data.shape_keys
-    bodykeys = obj2.data.shape_keys
-    eylsname = Global.get_KeepEyls_name()
+    def integrationEyelashes(self):
+        Global.setOpsMode('OBJECT')
+        obj1 = Global.getEyls()
+        obj2 = Global.getBody()
+        eyelashkeys = obj1.data.shape_keys
+        bodykeys = obj2.data.shape_keys
+        eylsname = Global.get_KeepEyls_name()
 
-    if eylsname.endswith(".Shape"):
-        eylsname = eylsname[:len(eylsname)-6]
+        if eylsname.endswith(".Shape"):
+            eylsname = eylsname[:len(eylsname)-6]
 
-    if eylsname !="":
-        eylsname = eylsname+"__"
+        if eylsname !="":
+            eylsname = eylsname+"__"
 
-    bodyname = Global.get_Body_name()
-    if bodyname.endswith(".Shape"):
-        bodyname = bodyname[:len(bodyname)-6]
+        bodyname = Global.get_Body_name()
+        if bodyname.endswith(".Shape"):
+            bodyname = bodyname[:len(bodyname)-6]
 
-    if bodyname !="":
-        bodyname = bodyname+"__"
-    
-    # First, before joinng, rename morphs to have the same name, blender will combine them when we join the objects
-    # this is MUCH faster than joining first then deleting morphs
-    # this provides a massive performance increasing when importing a lot of morphs
-    if eyelashkeys is not None and eylsname!="":
-        for keyIdx in range(len(eyelashkeys.key_blocks)):
-            shapekey = obj1.data.shape_keys.key_blocks[keyIdx]
-            if  (eylsname in shapekey.name):
-                print('renaming ' + shapekey.name + " to " + shapekey.name.replace(eylsname, ""))
-                shapekey.name = shapekey.name.replace(eylsname, "")
-            else:
-                print('skipping rename of ' + shapekey.name)
+        if bodyname !="":
+            bodyname = bodyname+"__"
+        
+        # First, before joinng, rename morphs to have the same name, blender will combine them when we join the objects
+        # this is MUCH faster than joining first then deleting morphs
+        # this provides a massive performance increasing when importing a lot of morphs
+        if eyelashkeys is not None and eylsname!="":
+            for keyIdx in range(len(eyelashkeys.key_blocks)):
+                shapekey = obj1.data.shape_keys.key_blocks[keyIdx]
+                if  (eylsname in shapekey.name):
+                    print('renaming ' + shapekey.name + " to " + shapekey.name.replace(eylsname, ""))
+                    shapekey.name = shapekey.name.replace(eylsname, "")
+                else:
+                    print('skipping rename of ' + shapekey.name)
 
-    if bodykeys is not None and bodyname!="":
-        for keyIdx in range(len(bodykeys.key_blocks)):
-            shapekey = obj2.data.shape_keys.key_blocks[keyIdx]
-            if  (bodyname in shapekey.name):
-                print('renaming ' + shapekey.name + " to " + shapekey.name.replace(bodyname, ""))
-                shapekey.name = shapekey.name.replace(bodyname, "")
-            else:
-                print('skipping rename of ' + shapekey.name)
+        if bodykeys is not None and bodyname!="":
+            for keyIdx in range(len(bodykeys.key_blocks)):
+                shapekey = obj2.data.shape_keys.key_blocks[keyIdx]
+                if  (bodyname in shapekey.name):
+                    print('renaming ' + shapekey.name + " to " + shapekey.name.replace(bodyname, ""))
+                    shapekey.name = shapekey.name.replace(bodyname, "")
+                else:
+                    print('skipping rename of ' + shapekey.name)
 
-    Versions.select(obj1,True)
-    Versions.select(obj2,True)
-    Versions.active_object(obj1)
-    Versions.active_object(obj2)
-    bpy.ops.object.join()
+        Versions.select(obj1,True)
+        Versions.select(obj2,True)
+        Versions.active_object(obj1)
+        Versions.active_object(obj2)
+        bpy.ops.object.join()
 
     def unwrapuv(self):
         Global.setOpsMode('OBJECT')

--- a/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/DazRigBlend.py
+++ b/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/DazRigBlend.py
@@ -183,15 +183,53 @@ class DazRigBlend:
                 for d in del_vgs:
                     vgs[d].add([v.index], 1.0, 'SUBTRACT')
 
-    def integrationEyelashes(self):
-        Global.setOpsMode('OBJECT')
-        obj1 = Global.getEyls()
-        obj2 = Global.getBody()
-        Versions.select(obj1,True)
-        Versions.select(obj2,True)
-        Versions.active_object(obj1)
-        Versions.active_object(obj2)
-        bpy.ops.object.join()
+def integrationEyelashes(self):
+    Global.setOpsMode('OBJECT')
+    obj1 = Global.getEyls()
+    obj2 = Global.getBody()
+    eyelashkeys = obj1.data.shape_keys
+    bodykeys = obj2.data.shape_keys
+    eylsname = Global.get_KeepEyls_name()
+
+    if eylsname.endswith(".Shape"):
+        eylsname = eylsname[:len(eylsname)-6]
+
+    if eylsname !="":
+        eylsname = eylsname+"__"
+
+    bodyname = Global.get_Body_name()
+    if bodyname.endswith(".Shape"):
+        bodyname = bodyname[:len(bodyname)-6]
+
+    if bodyname !="":
+        bodyname = bodyname+"__"
+    
+    # First, before joinng, rename morphs to have the same name, blender will combine them when we join the objects
+    # this is MUCH faster than joining first then deleting morphs
+    # this provides a massive performance increasing when importing a lot of morphs
+    if eyelashkeys is not None and eylsname!="":
+        for keyIdx in range(len(eyelashkeys.key_blocks)):
+            shapekey = obj1.data.shape_keys.key_blocks[keyIdx]
+            if  (eylsname in shapekey.name):
+                print('renaming ' + shapekey.name + " to " + shapekey.name.replace(eylsname, ""))
+                shapekey.name = shapekey.name.replace(eylsname, "")
+            else:
+                print('skipping rename of ' + shapekey.name)
+
+    if bodykeys is not None and bodyname!="":
+        for keyIdx in range(len(bodykeys.key_blocks)):
+            shapekey = obj2.data.shape_keys.key_blocks[keyIdx]
+            if  (bodyname in shapekey.name):
+                print('renaming ' + shapekey.name + " to " + shapekey.name.replace(bodyname, ""))
+                shapekey.name = shapekey.name.replace(bodyname, "")
+            else:
+                print('skipping rename of ' + shapekey.name)
+
+    Versions.select(obj1,True)
+    Versions.select(obj2,True)
+    Versions.active_object(obj1)
+    Versions.active_object(obj2)
+    bpy.ops.object.join()
 
     def unwrapuv(self):
         Global.setOpsMode('OBJECT')

--- a/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/__init__.py
+++ b/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/__init__.py
@@ -287,7 +287,7 @@ class IMP_OT_FBX(bpy.types.Operator):
             drb.unwrapuv()
             Global.deselect()
             if Global.getIsEyls():
-                #drb.integrationEyelashes()
+                drb.integrationEyelashes()
                 Global.deselect()
             ds.makeDct()
             DtbMaterial.McySkin()

--- a/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/__init__.py
+++ b/Blender/appdata_common/Blender Foundation/Blender/BLENDER_VERSION/scripts/addons/DTB/__init__.py
@@ -287,7 +287,7 @@ class IMP_OT_FBX(bpy.types.Operator):
             drb.unwrapuv()
             Global.deselect()
             if Global.getIsEyls():
-                drb.integrationEyelashes()
+                #drb.integrationEyelashes()
                 Global.deselect()
             ds.makeDct()
             DtbMaterial.McySkin()


### PR DESCRIPTION
Hi, I don't expect you too use this PR directly, because I think it probably messes things up further down the import pipeline (stuff i don't personally use), but you should consider looking at the code and integrating it in some way.

This massively increases the performance of the importer when importing a gen8 character with a lot of morphs.

The main issue causing a slow is deleting the eyelash morphs after joining the eyelash and body meshes. This is extremely slow and was taking 1+ hour (and still running before i cancelled it) on my machine because blender only lets you delete 1 at a time. You can get around this by naming the eyelash morphs and body morphs the same on each object and THEN joining the objects together. Blender will automatically combine the morphs and you no longer have to delete eyelash morphs. This massively improved performance. I only tested this on gen8 base female so far.

Hope this helps.

With this change to the code it imports in around 5 minutes instead of 1+ hours for me.